### PR TITLE
Authorization middleware

### DIFF
--- a/backend/src/middlewares/authenticationMiddleware.js
+++ b/backend/src/middlewares/authenticationMiddleware.js
@@ -1,7 +1,7 @@
 import jwtLib from 'jsonwebtoken';
 
 function verifyJwt(req, res, next) {
-	if (false) {     // trigger to desativate the middleware, must be removed
+	if (true) {     // trigger to desativate the middleware, must be removed
 		const jwt = req.header('Authorization');
 
 		if (!jwt) {

--- a/backend/src/middlewares/authorizationMiddleware.js
+++ b/backend/src/middlewares/authorizationMiddleware.js
@@ -1,0 +1,14 @@
+function verifyAuthorization({nivel_acesso}) {
+	return (req, res, next) => {
+		if (true) { // trigger to desativate the middleware, must be removed
+			if (req.header('access-level') >= nivel_acesso) {
+				next();
+			} else {
+				return res.status(401).json({ message: 'Baixo nível de acesso!' });
+			}
+		} else {
+			next();
+		}
+	};
+}
+export default verifyAuthorization;

--- a/backend/src/routes/alertaRoutes.js
+++ b/backend/src/routes/alertaRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import AlertaController from '../controllers/alertaController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js'
 
 const router = express.Router();
 
-router.get('/alerta', authenticationMiddleware, AlertaController.getAllEntities, () => {
+router.get('/alerta', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), AlertaController.getAllEntities, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.get('/alerta/:id', authenticationMiddleware, AlertaController.getEntityById, () => {
+router.get('/alerta/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), AlertaController.getEntityById, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.post('/alerta', authenticationMiddleware, AlertaController.createEntity, () => {
+router.post('/alerta', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), AlertaController.createEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.put('/alerta/:id', authenticationMiddleware, AlertaController.updateEntity, () => {
+router.put('/alerta/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), AlertaController.updateEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.delete('/alerta/:id', authenticationMiddleware, AlertaController.deleteEntity, () => {
+router.delete('/alerta/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), AlertaController.deleteEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 

--- a/backend/src/routes/alertaRoutes.js
+++ b/backend/src/routes/alertaRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import AlertaController from '../controllers/alertaController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/alerta', authorizationMiddleware, AlertaController.getAllEntities, () => {
+router.get('/alerta', authenticationMiddleware, AlertaController.getAllEntities, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.get('/alerta/:id', authorizationMiddleware, AlertaController.getEntityById, () => {
+router.get('/alerta/:id', authenticationMiddleware, AlertaController.getEntityById, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.post('/alerta', authorizationMiddleware, AlertaController.createEntity, () => {
+router.post('/alerta', authenticationMiddleware, AlertaController.createEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.put('/alerta/:id', authorizationMiddleware, AlertaController.updateEntity, () => {
+router.put('/alerta/:id', authenticationMiddleware, AlertaController.updateEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 
-router.delete('/alerta/:id', authorizationMiddleware, AlertaController.deleteEntity, () => {
+router.delete('/alerta/:id', authenticationMiddleware, AlertaController.deleteEntity, () => {
   /* #swagger.tags = ['Alerta'] */
 });
 

--- a/backend/src/routes/dependenteRoutes.js
+++ b/backend/src/routes/dependenteRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import DependenteController from '../controllers/dependenteController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/dependente', authenticationMiddleware, DependenteController.getAllEntities, () => {
+router.get('/dependente', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), DependenteController.getAllEntities, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.get('/dependente/:id', authenticationMiddleware, DependenteController.getEntityById, () => {
+router.get('/dependente/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), DependenteController.getEntityById, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.post('/dependente', authenticationMiddleware, DependenteController.createEntity, () => {
+router.post('/dependente', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), DependenteController.createEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.put('/dependente/:id', authenticationMiddleware, DependenteController.updateEntity, () => {
+router.put('/dependente/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), DependenteController.updateEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.delete('/dependente/:id', authenticationMiddleware, DependenteController.deleteEntity, () => {
+router.delete('/dependente/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), DependenteController.deleteEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 

--- a/backend/src/routes/dependenteRoutes.js
+++ b/backend/src/routes/dependenteRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import DependenteController from '../controllers/dependenteController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/dependente', authorizationMiddleware, DependenteController.getAllEntities, () => {
+router.get('/dependente', authenticationMiddleware, DependenteController.getAllEntities, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.get('/dependente/:id', authorizationMiddleware, DependenteController.getEntityById, () => {
+router.get('/dependente/:id', authenticationMiddleware, DependenteController.getEntityById, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.post('/dependente', authorizationMiddleware, DependenteController.createEntity, () => {
+router.post('/dependente', authenticationMiddleware, DependenteController.createEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.put('/dependente/:id', authorizationMiddleware, DependenteController.updateEntity, () => {
+router.put('/dependente/:id', authenticationMiddleware, DependenteController.updateEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 
-router.delete('/dependente/:id', authorizationMiddleware, DependenteController.deleteEntity, () => {
+router.delete('/dependente/:id', authenticationMiddleware, DependenteController.deleteEntity, () => {
   /* #swagger.tags = ['Dependente'] */
 });
 

--- a/backend/src/routes/efetivoRoutes.js
+++ b/backend/src/routes/efetivoRoutes.js
@@ -1,18 +1,19 @@
 import express from 'express';
 import EfetivoController from '../controllers/efetivoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js'
 
 const router = express.Router();
 
-router.get('/efetivo', authenticationMiddleware, EfetivoController.getAllEntities, () => {
+router.get('/efetivo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), EfetivoController.getAllEntities, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.get('/efetivo/:id', authenticationMiddleware, EfetivoController.getEntityById, () => {
+router.get('/efetivo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), EfetivoController.getEntityById, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.post('/efetivo', authenticationMiddleware, EfetivoController.createEntity, () => {
+router.post('/efetivo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), EfetivoController.createEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
@@ -20,11 +21,11 @@ router.post('/efetivoLogin', EfetivoController.login, () => {
 	/* #swagger.tags = ['Efetivo'] */
 });
 
-router.put('/efetivo/:id', authenticationMiddleware, EfetivoController.updateEntity, () => {
+router.put('/efetivo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), EfetivoController.updateEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.delete('/efetivo/:id', authenticationMiddleware, EfetivoController.deleteEntity, () => {
+router.delete('/efetivo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), EfetivoController.deleteEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 

--- a/backend/src/routes/efetivoRoutes.js
+++ b/backend/src/routes/efetivoRoutes.js
@@ -1,18 +1,18 @@
 import express from 'express';
 import EfetivoController from '../controllers/efetivoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/efetivo', authorizationMiddleware, EfetivoController.getAllEntities, () => {
+router.get('/efetivo', authenticationMiddleware, EfetivoController.getAllEntities, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.get('/efetivo/:id', authorizationMiddleware, EfetivoController.getEntityById, () => {
+router.get('/efetivo/:id', authenticationMiddleware, EfetivoController.getEntityById, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.post('/efetivo', authorizationMiddleware, EfetivoController.createEntity, () => {
+router.post('/efetivo', authenticationMiddleware, EfetivoController.createEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
@@ -20,11 +20,11 @@ router.post('/efetivoLogin', EfetivoController.login, () => {
 	/* #swagger.tags = ['Efetivo'] */
 });
 
-router.put('/efetivo/:id', authorizationMiddleware, EfetivoController.updateEntity, () => {
+router.put('/efetivo/:id', authenticationMiddleware, EfetivoController.updateEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 
-router.delete('/efetivo/:id', authorizationMiddleware, EfetivoController.deleteEntity, () => {
+router.delete('/efetivo/:id', authenticationMiddleware, EfetivoController.deleteEntity, () => {
   /* #swagger.tags = ['Efetivo'] */
 });
 

--- a/backend/src/routes/graduacaoRoutes.js
+++ b/backend/src/routes/graduacaoRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import GraduacaoController from '../controllers/graduacaoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/graduacao', authorizationMiddleware, GraduacaoController.getAllEntities, () => {
+router.get('/graduacao', authenticationMiddleware, GraduacaoController.getAllEntities, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.get('/graduacao/:id', authorizationMiddleware, GraduacaoController.getEntityById, () => {
+router.get('/graduacao/:id', authenticationMiddleware, GraduacaoController.getEntityById, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.post('/graduacao', authorizationMiddleware, GraduacaoController.createEntity, () => {
+router.post('/graduacao', authenticationMiddleware, GraduacaoController.createEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.put('/graduacao/:id', authorizationMiddleware, GraduacaoController.updateEntity, () => {
+router.put('/graduacao/:id', authenticationMiddleware, GraduacaoController.updateEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.delete('/graduacao/:id', authorizationMiddleware, GraduacaoController.deleteEntity, () => {
+router.delete('/graduacao/:id', authenticationMiddleware, GraduacaoController.deleteEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 

--- a/backend/src/routes/graduacaoRoutes.js
+++ b/backend/src/routes/graduacaoRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import GraduacaoController from '../controllers/graduacaoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/graduacao', authenticationMiddleware, GraduacaoController.getAllEntities, () => {
+router.get('/graduacao', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), GraduacaoController.getAllEntities, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.get('/graduacao/:id', authenticationMiddleware, GraduacaoController.getEntityById, () => {
+router.get('/graduacao/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), GraduacaoController.getEntityById, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.post('/graduacao', authenticationMiddleware, GraduacaoController.createEntity, () => {
+router.post('/graduacao', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), GraduacaoController.createEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.put('/graduacao/:id', authenticationMiddleware, GraduacaoController.updateEntity, () => {
+router.put('/graduacao/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), GraduacaoController.updateEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 
-router.delete('/graduacao/:id', authenticationMiddleware, GraduacaoController.deleteEntity, () => {
+router.delete('/graduacao/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), GraduacaoController.deleteEntity, () => {
   /* #swagger.tags = ['Graduacao'] */
 });
 

--- a/backend/src/routes/postoRoutes.js
+++ b/backend/src/routes/postoRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import PostoController from '../controllers/postoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/posto', authorizationMiddleware, PostoController.getAllEntities, () => {
+router.get('/posto', authenticationMiddleware, PostoController.getAllEntities, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.get('/posto/:id', authorizationMiddleware, PostoController.getEntityById, () => {
+router.get('/posto/:id', authenticationMiddleware, PostoController.getEntityById, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.post('/posto', authorizationMiddleware, PostoController.createEntity, () => {
+router.post('/posto', authenticationMiddleware, PostoController.createEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.put('/posto/:id', authorizationMiddleware, PostoController.updateEntity, () => {
+router.put('/posto/:id', authenticationMiddleware, PostoController.updateEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.delete('/posto/:id', authorizationMiddleware, PostoController.deleteEntity, () => {
+router.delete('/posto/:id', authenticationMiddleware, PostoController.deleteEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 

--- a/backend/src/routes/postoRoutes.js
+++ b/backend/src/routes/postoRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import PostoController from '../controllers/postoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/posto', authenticationMiddleware, PostoController.getAllEntities, () => {
+router.get('/posto', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), PostoController.getAllEntities, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.get('/posto/:id', authenticationMiddleware, PostoController.getEntityById, () => {
+router.get('/posto/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), PostoController.getEntityById, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.post('/posto', authenticationMiddleware, PostoController.createEntity, () => {
+router.post('/posto', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), PostoController.createEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.put('/posto/:id', authenticationMiddleware, PostoController.updateEntity, () => {
+router.put('/posto/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), PostoController.updateEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 
-router.delete('/posto/:id', authenticationMiddleware, PostoController.deleteEntity, () => {
+router.delete('/posto/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), PostoController.deleteEntity, () => {
   /* #swagger.tags = ['Posto'] */
 });
 

--- a/backend/src/routes/qrcodeRoutes.js
+++ b/backend/src/routes/qrcodeRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import QRCodeController from '../controllers/qrcodeController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/qrcode', authorizationMiddleware, QRCodeController.getAllEntities, () => {
+router.get('/qrcode', authenticationMiddleware, QRCodeController.getAllEntities, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.get('/qrcode/:qrcode', authorizationMiddleware, QRCodeController.getEntityByQRCode, () => {
+router.get('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.getEntityByQRCode, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.post('/qrcode', authorizationMiddleware, QRCodeController.createEntity, () => {
+router.post('/qrcode', authenticationMiddleware, QRCodeController.createEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.put('/qrcode/:qrcode', authorizationMiddleware, QRCodeController.updateEntity, () => {
+router.put('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.updateEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.delete('/qrcode/:qrcode', authorizationMiddleware, QRCodeController.deleteEntity, () => {
+router.delete('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.deleteEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 

--- a/backend/src/routes/qrcodeRoutes.js
+++ b/backend/src/routes/qrcodeRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import QRCodeController from '../controllers/qrcodeController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/qrcode', authenticationMiddleware, QRCodeController.getAllEntities, () => {
+router.get('/qrcode', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), QRCodeController.getAllEntities, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.get('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.getEntityByQRCode, () => {
+router.get('/qrcode/:qrcode', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), QRCodeController.getEntityByQRCode, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.post('/qrcode', authenticationMiddleware, QRCodeController.createEntity, () => {
+router.post('/qrcode', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), QRCodeController.createEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.put('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.updateEntity, () => {
+router.put('/qrcode/:qrcode', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), QRCodeController.updateEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 
-router.delete('/qrcode/:qrcode', authenticationMiddleware, QRCodeController.deleteEntity, () => {
+router.delete('/qrcode/:qrcode', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), QRCodeController.deleteEntity, () => {
   /* #swagger.tags = ['QRCode'] */
 });
 

--- a/backend/src/routes/registroAcessoRoutes.js
+++ b/backend/src/routes/registroAcessoRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import RegistroAcessoController from '../controllers/registroAcessoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/registro_acesso', authorizationMiddleware, RegistroAcessoController.getAllEntities, () => {
+router.get('/registro_acesso', authenticationMiddleware, RegistroAcessoController.getAllEntities, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.get('/registro_acesso/:id', authorizationMiddleware, RegistroAcessoController.getEntityById, () => {
+router.get('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.getEntityById, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.post('/registro_acesso', authorizationMiddleware, RegistroAcessoController.createEntity, () => {
+router.post('/registro_acesso', authenticationMiddleware, RegistroAcessoController.createEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.put('/registro_acesso/:id', authorizationMiddleware, RegistroAcessoController.updateEntity, () => {
+router.put('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.updateEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.delete('/registro_acesso/:id', authorizationMiddleware, RegistroAcessoController.deleteEntity, () => {
+router.delete('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.deleteEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 

--- a/backend/src/routes/registroAcessoRoutes.js
+++ b/backend/src/routes/registroAcessoRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import RegistroAcessoController from '../controllers/registroAcessoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/registro_acesso', authenticationMiddleware, RegistroAcessoController.getAllEntities, () => {
+router.get('/registro_acesso', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), RegistroAcessoController.getAllEntities, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.get('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.getEntityById, () => {
+router.get('/registro_acesso/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), RegistroAcessoController.getEntityById, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.post('/registro_acesso', authenticationMiddleware, RegistroAcessoController.createEntity, () => {
+router.post('/registro_acesso', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), RegistroAcessoController.createEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.put('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.updateEntity, () => {
+router.put('/registro_acesso/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), RegistroAcessoController.updateEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 
-router.delete('/registro_acesso/:id', authenticationMiddleware, RegistroAcessoController.deleteEntity, () => {
+router.delete('/registro_acesso/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), RegistroAcessoController.deleteEntity, () => {
   /* #swagger.tags = ['RegistroAcesso'] */
 });
 

--- a/backend/src/routes/sincronismoRoutes.js
+++ b/backend/src/routes/sincronismoRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import SincronismoController from '../controllers/sincronismoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/sincronismo', authenticationMiddleware, SincronismoController.getAllEntities, () => {
+router.get('/sincronismo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), SincronismoController.getAllEntities, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.get('/sincronismo/:id', authenticationMiddleware, SincronismoController.getEntityById, () => {
+router.get('/sincronismo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), SincronismoController.getEntityById, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.post('/sincronismo', authenticationMiddleware, SincronismoController.createEntity, () => {
+router.post('/sincronismo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), SincronismoController.createEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.put('/sincronismo/:id', authenticationMiddleware, SincronismoController.updateEntity, () => {
+router.put('/sincronismo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), SincronismoController.updateEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.delete('/sincronismo/:id', authenticationMiddleware, SincronismoController.deleteEntity, () => {
+router.delete('/sincronismo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), SincronismoController.deleteEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 

--- a/backend/src/routes/sincronismoRoutes.js
+++ b/backend/src/routes/sincronismoRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import SincronismoController from '../controllers/sincronismoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/sincronismo', authorizationMiddleware, SincronismoController.getAllEntities, () => {
+router.get('/sincronismo', authenticationMiddleware, SincronismoController.getAllEntities, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.get('/sincronismo/:id', authorizationMiddleware, SincronismoController.getEntityById, () => {
+router.get('/sincronismo/:id', authenticationMiddleware, SincronismoController.getEntityById, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.post('/sincronismo', authorizationMiddleware, SincronismoController.createEntity, () => {
+router.post('/sincronismo', authenticationMiddleware, SincronismoController.createEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.put('/sincronismo/:id', authorizationMiddleware, SincronismoController.updateEntity, () => {
+router.put('/sincronismo/:id', authenticationMiddleware, SincronismoController.updateEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 
-router.delete('/sincronismo/:id', authorizationMiddleware, SincronismoController.deleteEntity, () => {
+router.delete('/sincronismo/:id', authenticationMiddleware, SincronismoController.deleteEntity, () => {
   /* #swagger.tags = ['Sincronismo'] */
 });
 

--- a/backend/src/routes/unidadeRoutes.js
+++ b/backend/src/routes/unidadeRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import UnidadeController from '../controllers/unidadeController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/unidade', authorizationMiddleware, UnidadeController.getAllEntities, () => {
+router.get('/unidade', authenticationMiddleware, UnidadeController.getAllEntities, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.get('/unidade/:id', authorizationMiddleware, UnidadeController.getEntityById, () => {
+router.get('/unidade/:id', authenticationMiddleware, UnidadeController.getEntityById, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.post('/unidade', authorizationMiddleware, UnidadeController.createEntity, () => {
+router.post('/unidade', authenticationMiddleware, UnidadeController.createEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.put('/unidade/:id', authorizationMiddleware, UnidadeController.updateEntity, () => {
+router.put('/unidade/:id', authenticationMiddleware, UnidadeController.updateEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.delete('/unidade/:id', authorizationMiddleware, UnidadeController.deleteEntity, () => {
+router.delete('/unidade/:id', authenticationMiddleware, UnidadeController.deleteEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 

--- a/backend/src/routes/unidadeRoutes.js
+++ b/backend/src/routes/unidadeRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import UnidadeController from '../controllers/unidadeController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/unidade', authenticationMiddleware, UnidadeController.getAllEntities, () => {
+router.get('/unidade', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UnidadeController.getAllEntities, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.get('/unidade/:id', authenticationMiddleware, UnidadeController.getEntityById, () => {
+router.get('/unidade/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UnidadeController.getEntityById, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.post('/unidade', authenticationMiddleware, UnidadeController.createEntity, () => {
+router.post('/unidade', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UnidadeController.createEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.put('/unidade/:id', authenticationMiddleware, UnidadeController.updateEntity, () => {
+router.put('/unidade/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UnidadeController.updateEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 
-router.delete('/unidade/:id', authenticationMiddleware, UnidadeController.deleteEntity, () => {
+router.delete('/unidade/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UnidadeController.deleteEntity, () => {
   /* #swagger.tags = ['Unidade'] */
 });
 

--- a/backend/src/routes/usuarioRoutes.js
+++ b/backend/src/routes/usuarioRoutes.js
@@ -1,22 +1,23 @@
 import express from 'express';
 import UsuarioController from '../controllers/usuarioController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/usuario', authenticationMiddleware, UsuarioController.getAllEntities, () => {
+router.get('/usuario', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), UsuarioController.getAllEntities, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.get('/usuario/:id', authenticationMiddleware, UsuarioController.getEntityById, () => {
+router.get('/usuario/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  UsuarioController.getEntityById, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.post('/usuario', authenticationMiddleware, UsuarioController.createEntity, () => {
+router.post('/usuario', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  UsuarioController.createEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.put('/usuario/:id', authenticationMiddleware, UsuarioController.updateEntity, () => {
+router.put('/usuario/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  UsuarioController.updateEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
@@ -24,7 +25,7 @@ router.post('/usuarioLogin', UsuarioController.login, () => {
 	/* #swagger.tags = ['Usuario'] */
 });
 
-router.delete('/usuario/:id', authenticationMiddleware, UsuarioController.deleteEntity, () => {
+router.delete('/usuario/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  UsuarioController.deleteEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 

--- a/backend/src/routes/usuarioRoutes.js
+++ b/backend/src/routes/usuarioRoutes.js
@@ -1,22 +1,22 @@
 import express from 'express';
 import UsuarioController from '../controllers/usuarioController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/usuario', authorizationMiddleware, UsuarioController.getAllEntities, () => {
+router.get('/usuario', authenticationMiddleware, UsuarioController.getAllEntities, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.get('/usuario/:id', authorizationMiddleware, UsuarioController.getEntityById, () => {
+router.get('/usuario/:id', authenticationMiddleware, UsuarioController.getEntityById, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.post('/usuario', UsuarioController.createEntity, () => {
+router.post('/usuario', authenticationMiddleware, UsuarioController.createEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
-router.put('/usuario/:id', UsuarioController.updateEntity, () => {
+router.put('/usuario/:id', authenticationMiddleware, UsuarioController.updateEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 
@@ -24,7 +24,7 @@ router.post('/usuarioLogin', UsuarioController.login, () => {
 	/* #swagger.tags = ['Usuario'] */
 });
 
-router.delete('/usuario/:id', authorizationMiddleware, UsuarioController.deleteEntity, () => {
+router.delete('/usuario/:id', authenticationMiddleware, UsuarioController.deleteEntity, () => {
 	/* #swagger.tags = ['Usuario']*/
 });
 

--- a/backend/src/routes/veiculoRoutes.js
+++ b/backend/src/routes/veiculoRoutes.js
@@ -1,26 +1,26 @@
 import express from 'express';
 import VeiculoController from '../controllers/veiculoController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/veiculo', authorizationMiddleware, VeiculoController.getAllEntities, () => {
+router.get('/veiculo', authenticationMiddleware, VeiculoController.getAllEntities, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.get('/veiculo/:id', authorizationMiddleware, VeiculoController.getEntityById, () => {
+router.get('/veiculo/:id', authenticationMiddleware, VeiculoController.getEntityById, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.post('/veiculo', authorizationMiddleware, VeiculoController.createEntity, () => {
+router.post('/veiculo', authenticationMiddleware, VeiculoController.createEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.put('/veiculo/:id', authorizationMiddleware, VeiculoController.updateEntity, () => {
+router.put('/veiculo/:id', authenticationMiddleware, VeiculoController.updateEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.delete('/veiculo/:id', authorizationMiddleware, VeiculoController.deleteEntity, () => {
+router.delete('/veiculo/:id', authenticationMiddleware, VeiculoController.deleteEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 

--- a/backend/src/routes/veiculoRoutes.js
+++ b/backend/src/routes/veiculoRoutes.js
@@ -1,26 +1,27 @@
 import express from 'express';
 import VeiculoController from '../controllers/veiculoController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/veiculo', authenticationMiddleware, VeiculoController.getAllEntities, () => {
+router.get('/veiculo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  VeiculoController.getAllEntities, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.get('/veiculo/:id', authenticationMiddleware, VeiculoController.getEntityById, () => {
+router.get('/veiculo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  VeiculoController.getEntityById, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.post('/veiculo', authenticationMiddleware, VeiculoController.createEntity, () => {
+router.post('/veiculo', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  VeiculoController.createEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.put('/veiculo/:id', authenticationMiddleware, VeiculoController.updateEntity, () => {
+router.put('/veiculo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  VeiculoController.updateEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 
-router.delete('/veiculo/:id', authenticationMiddleware, VeiculoController.deleteEntity, () => {
+router.delete('/veiculo/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}),  VeiculoController.deleteEntity, () => {
   /* #swagger.tags = ['Veiculo'] */
 });
 

--- a/backend/src/routes/visitanteRoutes.js
+++ b/backend/src/routes/visitanteRoutes.js
@@ -1,18 +1,19 @@
 import express from 'express';
 import VisitanteController from '../controllers/visitanteController.js';
 import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
+import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/visitante', authenticationMiddleware, VisitanteController.getAllEntities, () => {
+router.get('/visitante', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), VisitanteController.getAllEntities, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.get('/visitante/:id', authenticationMiddleware, VisitanteController.getEntityById, () => {
+router.get('/visitante/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), VisitanteController.getEntityById, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.post('/visitante', authenticationMiddleware, VisitanteController.createEntity, () => {
+router.post('/visitante', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), VisitanteController.createEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
@@ -20,11 +21,11 @@ router.post('/visitanteLogin', VisitanteController.login, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.put('/visitante/:id', authenticationMiddleware, VisitanteController.updateEntity, () => {
+router.put('/visitante/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), VisitanteController.updateEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.delete('/visitante/:id', authenticationMiddleware, VisitanteController.deleteEntity, () => {
+router.delete('/visitante/:id', authenticationMiddleware, authorizationMiddleware({nivel_acesso: 2}), VisitanteController.deleteEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 

--- a/backend/src/routes/visitanteRoutes.js
+++ b/backend/src/routes/visitanteRoutes.js
@@ -1,18 +1,18 @@
 import express from 'express';
 import VisitanteController from '../controllers/visitanteController.js';
-import authorizationMiddleware from '../middlewares/authorizationMiddleware.js';
+import authenticationMiddleware from '../middlewares/authenticationMiddleware.js';
 
 const router = express.Router();
 
-router.get('/visitante', authorizationMiddleware, VisitanteController.getAllEntities, () => {
+router.get('/visitante', authenticationMiddleware, VisitanteController.getAllEntities, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.get('/visitante/:id', authorizationMiddleware, VisitanteController.getEntityById, () => {
+router.get('/visitante/:id', authenticationMiddleware, VisitanteController.getEntityById, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.post('/visitante', authorizationMiddleware, VisitanteController.createEntity, () => {
+router.post('/visitante', authenticationMiddleware, VisitanteController.createEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
@@ -20,11 +20,11 @@ router.post('/visitanteLogin', VisitanteController.login, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.put('/visitante/:id', authorizationMiddleware, VisitanteController.updateEntity, () => {
+router.put('/visitante/:id', authenticationMiddleware, VisitanteController.updateEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 
-router.delete('/visitante/:id', authorizationMiddleware, VisitanteController.deleteEntity, () => {
+router.delete('/visitante/:id', authenticationMiddleware, VisitanteController.deleteEntity, () => {
 	/* #swagger.tags = ['Visitante'] */
 });
 


### PR DESCRIPTION
Before the deploy, it is important to review all the access levels, but for now, the middleware is implemented.

First, I renamed and changed all calls from authorizationMiddleware to authenticationMiddleware. Then, I created the authorizationMiddleware to handle the validation of access levels.

The access level is send in the header of request.

To make it easier to visualize the middleware exchange, if you want, you can analyze the first commit. I separated the commits of this part.