### PR TITLE
automate the creation of qr code

### DIFF
--- a/backend/src/controllers/dependenteController.js
+++ b/backend/src/controllers/dependenteController.js
@@ -1,4 +1,5 @@
 import Entity from '../models/Dependente.js';
+import QRCode from '../models/QRCode.js';
 
 class DependenteController {
 	static getAllEntities = async (req, res) => {
@@ -46,22 +47,28 @@ class DependenteController {
 
 	static createEntity = async (req, res) => {
 		try {
-			const { id_efetivo, nome, parentesco, qrcode, ativo_dependente, sinc_dependente } = req.body;
+			const { id_efetivo, nome, parentesco, nivel_acesso, ativo_dependente, sinc_dependente } = req.body;
+			
+			var createdQRCode = await QRCode.create({
+				nivel_acesso
+			});
 
 			const createdEntity = await Entity.create({
 				id_efetivo,
 				nome,
 				parentesco,
-				qrcode,
+				qrcode: createdQRCode.qrcode,
 				ativo_dependente,
 				sinc_dependente
 			});
-			res.status(201).json(createdEntity);
+			return res.status(201).json(createdEntity);
 		} catch (error) {
 			if (error.name == 'SequelizeUniqueConstraintError') {
-				res.status(400).send({ message: 'Valores já cadastrados!' });
+				createdQRCode.destroy();
+				return res.status(400).send({ message: 'Valores já cadastrados!' });
 			} else {
-				res.status(500).send({ message: `${error.message}` });
+				createdQRCode.destroy();
+				return res.status(500).send({ message: `${error.message}` });
 			}
 		}
 	};

--- a/backend/src/controllers/visitanteController.js
+++ b/backend/src/controllers/visitanteController.js
@@ -3,6 +3,7 @@ import verifyPassword from '../util/verifyPassword.js';
 import NoEntityError from '../util/customErrors/NoEntityError.js';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import QRCode from '../models/QRCode.js';
 
 class VisitanteController {
 	static getAllEntities = async (req, res) => {
@@ -67,12 +68,16 @@ class VisitanteController {
 				foto,
 				empresa,
 				autorizador,
-				qrcode_visitante,
+				nivel_acesso,
 				ativo_visitante,
 				sinc
 			} = req.body;
 
 			const senhaHashed = await bcrypt.hash(senha, 10);
+
+			var createdQRCode = await QRCode.create({
+				nivel_acesso
+			})
 
 			const createdEntity = await Entity.create({
 				email,
@@ -88,7 +93,7 @@ class VisitanteController {
 				foto,
 				empresa,
 				autorizador,
-				qrcode_visitante,
+				qrcode_visitante: createdQRCode.qrcode,
 				ativo_visitante,
 				sinc
 			});
@@ -98,8 +103,10 @@ class VisitanteController {
 			res.status(201).json(createdEntity);
 		} catch (error) {
 			if (error.name == 'SequelizeUniqueConstraintError') {
+				createdQRCode.destroy();
 				res.status(400).send({ message: 'Valores já cadastrados!' });
 			} else {
+				createdQRCode.destroy();
 				res.status(500).send({ message: `${error.message}` });
 			}
 		}


### PR DESCRIPTION
Instead of create a QR code and then assign to the efetivo / dependente / visitante, now the create of all this entities already creates a QR code and assign the ID automatically. If there is any error on the create of the entity, this automation also delete the QR code created for this entity, so the database will not keep the trash of this operation.